### PR TITLE
Always send uppercase method

### DIFF
--- a/src/EInnsynRequester.ts
+++ b/src/EInnsynRequester.ts
@@ -52,7 +52,7 @@ export class EInnsynRequester {
     const userAgent = appInfo ? `${appInfo} - ${userAgentBase}` : userAgentBase;
 
     const defaultRequestInit: RequestInit = {
-      method: method,
+      method: method.toUpperCase(),
       headers: {
         'Content-Type': 'application/json',
         'User-Agent': userAgent,


### PR DESCRIPTION
EInnsynRequester.request passed the method from its lowercase union ('get' | 'post' | 'patch' | 'delete') straight into RequestInit. The Fetch spec normalizes 'delete', 'get', 'head', 'options', 'post', 'put' to uppercase - not 'patch'.